### PR TITLE
Migration Pull Request

### DIFF
--- a/MyConsoleApp/Program.cs
+++ b/MyConsoleApp/Program.cs
@@ -1,27 +1,23 @@
-﻿using System.Net;
+using System;
+using System.Net.Http;
 
 namespace WebRequestSample
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             string url = "https://jsonplaceholder.typicode.com/todos/1";
 
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-            request.Method = "GET";
-            request.ContentType = "application/json";
-
-            using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+            using (HttpClient client = new HttpClient())
             {
-                if (response.StatusCode == HttpStatusCode.OK)
+                HttpResponseMessage response = await client.GetAsync(url);
+
+                if (response.IsSuccessStatusCode)
                 {
-                    using (StreamReader reader = new StreamReader(response.GetResponseStream()))
-                    {
-                        string responseText = reader.ReadToEnd();
-                        Console.WriteLine("Response received:");
-                        Console.WriteLine(responseText);
-                    }
+                    string responseText = await response.Content.ReadAsStringAsync();
+                    Console.WriteLine("Response received:");
+                    Console.WriteLine(responseText);
                 }
                 else
                 {


### PR DESCRIPTION
The main change needed to migrate this app from .NET 6 to .NET 8 is to update the way HTTP requests are made. In .NET 8, the `HttpWebRequest` class has been deprecated and replaced with the new `HttpClient` class. 

To make this migration, you need to replace the usage of `HttpWebRequest` with `HttpClient` and modify the code accordingly. Here is the corrected file: 

**Note**: This PR was generated by Copilot. It is part of the process to migrate the application. Please review and merge it as necessary.